### PR TITLE
build: enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,3 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "exports": "./index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "bin": {
     "octoherd-script-create-repositories-from-script-folders": "./cli.js"


### PR DESCRIPTION
## Summary

- Set `publishConfig.provenance: true` in `package.json` so npm publishes with [provenance attestations](https://docs.npmjs.com/generating-provenance-statements).
- Add `id-token: write` permission to the release workflow (required by npm's OIDC-based provenance).

Releases continue to run via semantic-release; no `--provenance` flag is needed because npm reads the value from `publishConfig`.

The remaining permissions (`contents`, `issues`, `pull-requests`) are added explicitly because adding any `permissions:` block disables the default token scopes — semantic-release needs those to create releases and comment on issues/PRs.

## Test plan

- [ ] Merge and confirm the next release publishes with provenance (visible on the npm package page under "Provenance").